### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,29 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Prepare dist folder
+        run: |
+          rm -rf dist
+          mkdir -p dist
+          rsync -av --exclude '.git' --exclude '.github' --exclude 'dist' ./ dist/
+          rm -rf dist/.git dist/.github
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: dist
+          keep_files: true


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that deploys the site on pushes to `main`
- prepare the `dist/` folder by copying the repository contents without VCS files before publishing
- publish the built files to the `gh-pages` branch using `peaceiris/actions-gh-pages@v3`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c88066daf8832f8a4d3110f81e44f2