### PR TITLE
Add PWA support with secure service worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Calcula cuántas **cucharadas** de café necesitas según:
 - Consumo por persona (capacidad del vaso, en mL)
 - Cuántas personas repiten
 - Tueste (claro/medio/oscuro) → fija la temperatura objetivo
+- Uso sin conexión e instalación como **PWA** en dispositivos compatibles
 
 **Proporción:** 1:16 (café:agua).  
 **Instrucción general:** hervir el agua, infusionar 4 min y colar en filtro grande de tela o filtro plástico del percolador.
@@ -14,7 +15,7 @@ Calcula cuántas **cucharadas** de café necesitas según:
 ## Publicar en GitHub Pages (paso a paso)
 
 1. Crea un repositorio nuevo en GitHub, por ejemplo `cafe-calculadora`.
-2. Sube estos archivos a la raíz del repo: `index.html`, `README.md`, `.nojekyll`, `favicon.png`, `LICENSE` (opcional).
+2. Sube estos archivos a la raíz del repo: `index.html`, `app.js`, `sw.js`, `manifest.webmanifest`, `README.md`, `.nojekyll`, `favicon.png`, `LICENSE` (opcional).
 3. En GitHub → *Settings* → *Pages*:
    - **Source**: selecciona **Deploy from a branch**.
    - **Branch**: elige `main` y la carpeta **/ (root)**. Guarda.
@@ -26,7 +27,11 @@ Calcula cuántas **cucharadas** de café necesitas según:
 
 ## Desarrollo local
 
-Abre `index.html` con tu navegador. No requiere dependencias ni build.
+Para que el *service worker* funcione correctamente necesitas servir la carpeta desde `https://` o `http://localhost`.
+
+1. Instala `serve` (u otro servidor estático) si no lo tienes: `npm install -g serve`.
+2. Ejecuta `serve .` (o `npx serve .`) dentro del proyecto.
+3. Abre `http://localhost:3000` (o el puerto indicado) en tu navegador.
 
 ---
 

--- a/app.js
+++ b/app.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const $ = (id) => document.getElementById(id);
+const tempMap = { claro: 100, medio: 95, oscuro: 90 };
+
+function getSelectedRoast() {
+  const el = document.querySelector('input[name="tueste"]:checked');
+  return el ? el.value : 'claro';
+}
+
+function validate(p, c, r) {
+  const issues = [];
+  if (!Number.isFinite(p) || p < 1) issues.push("• 'Cantidad de personas' debe ser al menos 1.");
+  if (!Number.isFinite(c) || c < 60) issues.push("• 'Consumo por persona' debe ser ≥ 60 mL.");
+  if (!Number.isFinite(r) || r < 0) issues.push("• '¿Cuántas personas repiten?' no puede ser negativa.");
+  if (Number.isFinite(p) && Number.isFinite(r) && r > p) {
+    issues.push(
+      "• Por claridad, 'personas que repiten' no debería exceder la cantidad de personas (se asume una repetición por persona)."
+    );
+  }
+  return issues;
+}
+
+function format(n, decimals = 1) {
+  return Number.isFinite(n) ? n.toFixed(decimals) : '—';
+}
+
+function calcular() {
+  const personas = parseFloat($("personas").value);
+  const capacidad = parseFloat($("capacidad").value);
+  const repiten = parseFloat($("repiten").value);
+  const gxtbsp = parseFloat($("gxtbsp").value);
+  const roast = getSelectedRoast();
+  const temp = tempMap[roast];
+
+  const issues = validate(personas, capacidad, repiten);
+  const alert = $("alert");
+  if (issues.length) {
+    alert.style.display = '';
+    alert.innerHTML = issues.join('<br>');
+    $("salida").style.display = 'none';
+    return;
+  }
+
+  alert.style.display = 'none';
+
+  const servidas = personas + repiten;
+  const aguaTotal = servidas * capacidad; // mL ≈ g
+  const gramosCafe = aguaTotal / 16.0; // 1:16
+  const cucharadas = gramosCafe / gxtbsp;
+
+  $("salida").style.display = '';
+  $("cucharadas").textContent = `${format(cucharadas, 1)} cucharadas`;
+  $("gramos").textContent = `${format(gramosCafe, 0)} g`;
+  $("agua").textContent = `${format(aguaTotal, 0)} mL`;
+  $("temp").textContent = `${temp} °C`;
+}
+
+function limpiar() {
+  $("personas").value = 4;
+  $("capacidad").value = 200;
+  $("repiten").value = 0;
+  $("gxtbsp").value = 6;
+  document.querySelector('input[name="tueste"][value="claro"]').checked = true;
+  $("alert").style.display = 'none';
+  $("salida").style.display = 'none';
+}
+
+async function registerServiceWorker() {
+  if (!('serviceWorker' in navigator)) {
+    return;
+  }
+  try {
+    await navigator.serviceWorker.register('sw.js');
+  } catch (error) {
+    console.error('No se pudo registrar el service worker:', error);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  $("calc").addEventListener('click', calcular);
+  $("reset").addEventListener('click', () => {
+    limpiar();
+  });
+  limpiar();
+  calcular();
+  registerServiceWorker();
+});

--- a/index.html
+++ b/index.html
@@ -5,11 +5,20 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Calculadora de Café (1:16)</title>
   <meta name="description" content="Calcula cuántas cucharadas de café necesitas según personas, tamaño de vaso y repetidores. Incluye tueste→temperatura (claro 100°C, medio 95°C, oscuro 90°C).">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'; manifest-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self';">
+  <meta name="application-name" content="Calculadora de Café" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="mobile-web-app-capable" content="yes" />
+  <meta name="theme-color" content="#0f172a" />
+  <meta name="color-scheme" content="dark light" />
   <meta property="og:title" content="Calculadora de Café (1:16)">
   <meta property="og:description" content="Cálculo rápido en cucharadas según personas, vaso, repiten y tueste.">
   <meta property="og:type" content="website">
   <meta property="og:image" content="favicon.png">
   <link rel="icon" href="favicon.png" />
+  <link rel="apple-touch-icon" href="favicon.png" />
+  <link rel="manifest" href="manifest.webmanifest" />
   <style>
     :root {
       --bg: #0f172a;
@@ -179,66 +188,6 @@
     </footer>
   </div>
 
-  <script>
-    const $ = (id) => document.getElementById(id);
-    const tempMap = { claro: 100, medio: 95, oscuro: 90 };
-
-    function getSelectedRoast() {
-      const el = document.querySelector('input[name="tueste"]:checked');
-      return el ? el.value : 'claro';
-    }
-    function validate(p, c, r) {
-      const issues = [];
-      if (!Number.isFinite(p) || p < 1) issues.push("• 'Cantidad de personas' debe ser al menos 1.");
-      if (!Number.isFinite(c) || c < 60) issues.push("• 'Consumo por persona' debe ser ≥ 60 mL.");
-      if (!Number.isFinite(r) || r < 0) issues.push("• '¿Cuántas personas repiten?' no puede ser negativa.");
-      if (Number.isFinite(p) && Number.isFinite(r) && r > p) {
-        issues.push("• Por claridad, 'personas que repiten' no debería exceder la cantidad de personas (se asume una repetición por persona).");
-      }
-      return issues;
-    }
-    function format(n, decimals=1) { return Number.isFinite(n) ? n.toFixed(decimals) : '—'; }
-    function calcular() {
-      const personas = parseFloat($("personas").value);
-      const capacidad = parseFloat($("capacidad").value);
-      const repiten   = parseFloat($("repiten").value);
-      const gxtbsp    = parseFloat($("gxtbsp").value);
-      const roast     = getSelectedRoast();
-      const temp      = tempMap[roast];
-
-      const issues = validate(personas, capacidad, repiten);
-      const alert = $("alert");
-      if (issues.length) {
-        alert.style.display = '';
-        alert.innerHTML = issues.join("<br>");
-        $("salida").style.display = 'none';
-        return;
-      } else {
-        alert.style.display = 'none';
-      }
-
-      const servidas = personas + repiten;
-      const aguaTotal = servidas * capacidad;    // mL ≈ g
-      const gramosCafe = aguaTotal / 16.0;       // 1:16
-      const cucharadas = gramosCafe / gxtbsp;
-
-      $("salida").style.display = '';
-      $("cucharadas").textContent = `${format(cucharadas, 1)} cucharadas`;
-      $("gramos").textContent = `${format(gramosCafe, 0)} g`;
-      $("agua").textContent = `${format(aguaTotal, 0)} mL`;
-      $("temp").textContent = `${temp} °C`;
-    }
-    $("calc").addEventListener("click", calcular);
-    $("reset").addEventListener("click", () => {
-      $("personas").value = 4;
-      $("capacidad").value = 200;
-      $("repiten").value = 0;
-      $("gxtbsp").value = 6;
-      document.querySelector('input[name="tueste"][value="claro"]').checked = true;
-      $("alert").style.display = 'none';
-      $("salida").style.display = 'none';
-    });
-    window.addEventListener('DOMContentLoaded', calcular);
-  </script>
+  <script src="app.js" defer></script>
 </body>
 </html>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,16 @@
+{
+  "name": "Calculadora de Café",
+  "short_name": "Café 1:16",
+  "start_url": "./",
+  "display": "standalone",
+  "description": "Calcula cuántas cucharadas de café y agua necesitas para una proporción 1:16.",
+  "background_color": "#0f172a",
+  "theme_color": "#0f172a",
+  "icons": [
+    {
+      "src": "favicon.png",
+      "sizes": "256x256",
+      "type": "image/png"
+    }
+  ]
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,57 @@
+const CACHE_NAME = 'coffee-calculator-v1';
+const ASSETS = ['./', './index.html', './app.js', './manifest.webmanifest', './favicon.png'];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => cache.addAll(ASSETS))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)))
+      )
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  if (request.method !== 'GET') {
+    return;
+  }
+
+  const requestUrl = new URL(request.url);
+  if (requestUrl.origin !== self.location.origin) {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(request, { ignoreSearch: true }).then((cachedResponse) => {
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+
+      return fetch(request)
+        .then((response) => {
+          if (response && response.ok) {
+            const copy = response.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(request, copy));
+          }
+          return response;
+        })
+        .catch(() => {
+          if (request.mode === 'navigate' || request.destination === 'document') {
+            return caches.match('./index.html');
+          }
+          return Response.error();
+        });
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- add a manifest, service worker and modular JavaScript to run the calculator as a PWA
- register the service worker with offline caching while keeping requests scoped to the site
- harden the page with a strict Content Security Policy and document the new PWA workflow

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cd8176c91c832f962230c7e78fddf7