### PR TITLE
Remove branch previews when branches are deleted

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -2,6 +2,8 @@ name: PR Preview
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened]
+  delete:
 
 permissions:
   contents: write
@@ -9,8 +11,28 @@ permissions:
 
 jobs:
   deploy:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    env:
+      BRANCH_NAME: ${{ github.head_ref }}
     steps:
+      - name: Set preview directory
+        run: |
+          branch="${BRANCH_NAME}"
+          if [ -z "${branch}" ]; then
+            echo "Branch name is empty; cannot determine preview directory." >&2
+            exit 1
+          fi
+
+          sanitized=$(printf '%s' "${branch}" | sed 's/[^A-Za-z0-9._-]/-/g')
+          sanitized="${sanitized#-}"
+          sanitized="${sanitized%-}"
+          if [ -z "${sanitized}" ]; then
+            echo "Sanitized branch name is empty; cannot determine preview directory." >&2
+            exit 1
+          fi
+          echo "PREVIEW_DIR=branch-${sanitized}" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v4
 
       - name: Build site
@@ -23,19 +45,70 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
           publish_dir: dist
-          destination_dir: pr-${{ github.event.number }}
+          destination_dir: ${{ env.PREVIEW_DIR }}
           keep_files: true
 
       - name: Comment preview URL
         uses: actions/github-script@v7
         with:
           script: |
-            const prNumber = context.payload.pull_request.number;
+            const previewDir = process.env.PREVIEW_DIR;
+            const branchName = process.env.BRANCH_NAME;
             const {owner, repo} = context.repo;
-            const url = `https://${owner}.github.io/${repo}/pr-${prNumber}/`;
+            const url = `https://${owner}.github.io/${repo}/${previewDir}/`;
             github.rest.issues.createComment({
-              issue_number: prNumber,
+              issue_number: context.payload.pull_request.number,
               owner,
               repo,
-              body: `Preview: ${url}`
+              body: `Preview for branch \`${branchName}\`: ${url}`
             });
+
+  cleanup:
+    if: github.event_name == 'delete' && github.event.ref_type == 'branch'
+    runs-on: ubuntu-latest
+    env:
+      BRANCH_NAME: ${{ github.event.ref }}
+    steps:
+      - name: Set preview directory
+        run: |
+          branch="${BRANCH_NAME}"
+          if [ -z "${branch}" ]; then
+            echo "Branch name is empty; cannot determine preview directory." >&2
+            exit 1
+          fi
+
+          sanitized=$(printf '%s' "${branch}" | sed 's/[^A-Za-z0-9._-]/-/g')
+          sanitized="${sanitized#-}"
+          sanitized="${sanitized%-}"
+          if [ -z "${sanitized}" ]; then
+            echo "Sanitized branch name is empty; cannot determine preview directory." >&2
+            exit 1
+          fi
+          echo "PREVIEW_DIR=branch-${sanitized}" >> "$GITHUB_ENV"
+
+      - name: Checkout GitHub Pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Delete preview site
+        run: |
+          if [ -z "${PREVIEW_DIR}" ]; then
+            echo "Preview directory is not set; skipping cleanup."
+            exit 0
+          fi
+
+          if [ -d "${PREVIEW_DIR}" ]; then
+            rm -rf "${PREVIEW_DIR}"
+            git config user.name "github-actions"
+            git config user.email "github-actions@github.com"
+            git add -A
+            if git diff --cached --quiet; then
+              echo "No preview directory to remove."
+            else
+              git commit -m "Remove preview for branch ${BRANCH_NAME}"
+              git push origin gh-pages
+            fi
+          else
+            echo "Preview directory ${PREVIEW_DIR} does not exist."
+          fi


### PR DESCRIPTION
## Summary
- derive the preview directory from the sanitized pull request branch name so its path can be reused after the branch lifecycle ends
- deploy previews only on pull request events and comment with the corresponding branch-specific URL
- add a cleanup job that listens for branch deletions, checks out `gh-pages`, and removes the matching preview directory

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ce53ad28d8832fb5df1a3265bbc59c